### PR TITLE
fix: webcord src patch now starts the client normally when adding themes

### DIFF
--- a/overrides/nodejs/default.nix
+++ b/overrides/nodejs/default.nix
@@ -78,6 +78,8 @@
         libXtst
       ]);
 
+    patches = [./patches/remove-dialog-box.patch];
+
     preConfigure = ''
       cp ${buildInfo} buildInfo.json
     '';

--- a/overrides/nodejs/patches/remove-dialog-box.patch
+++ b/overrides/nodejs/patches/remove-dialog-box.patch
@@ -1,14 +1,38 @@
-From 097b5e58ca8772fa2c03e27b7b53a424fa2c90f2 Mon Sep 17 00:00:00 2001
+From 7e9c1dec16a6650948e3612727a926deb9b7c9a4 Mon Sep 17 00:00:00 2001
 From: Ian McFarlane <i.mcfarlane2002@gmail.com>
-Date: Sat, 10 Sep 2022 10:19:11 -0400
-Subject: [PATCH] remove dialog box
+Date: Sun, 11 Sep 2022 21:41:23 -0400
+Subject: [PATCH] Remove dialog box and start webcord normally when using
+ --add-css-theme
 
 ---
+ sources/code/common/main.ts             |  6 ++----
  sources/code/main/modules/extensions.ts | 16 +++-------------
- 1 file changed, 3 insertions(+), 13 deletions(-)
+ 2 files changed, 5 insertions(+), 17 deletions(-)
 
+diff --git a/sources/code/common/main.ts b/sources/code/common/main.ts
+index 0486f07..4a2d701 100644
+--- a/sources/code/common/main.ts
++++ b/sources/code/common/main.ts
+@@ -259,9 +259,7 @@ let overwriteMain: (() => unknown) | undefined;
+     if(!path.endsWith(".theme.css"))
+       throw new Error("Value of flag 'add-css-theme' should point to '*.theme.css' file.");
+     overwriteMain = () => {
+-      styles.add(path)
+-        .then(() => process.exit(0))
+-        .catch(() => process.exit(1));
++      styles.add(path);
+     };
+   }
+ }
+@@ -446,4 +444,4 @@ if(new Date().getMonth() === 3 && new Date().getDate() === 1){
+   }
+   // Something's wrong with your date. Websites won't load, so crash the application.
+   throw new NotAnError("Invalid date! I think you should check your calendar...");
+-}
+\ No newline at end of file
++}
 diff --git a/sources/code/main/modules/extensions.ts b/sources/code/main/modules/extensions.ts
-index 74864ad..a56520d 100644
+index 69dafef..cc55a0b 100644
 --- a/sources/code/main/modules/extensions.ts
 +++ b/sources/code/main/modules/extensions.ts
 @@ -49,7 +49,7 @@ async function parseImports(cssString: string):Promise<string> {

--- a/overrides/nodejs/patches/remove-dialog-box.patch
+++ b/overrides/nodejs/patches/remove-dialog-box.patch
@@ -1,0 +1,51 @@
+From 097b5e58ca8772fa2c03e27b7b53a424fa2c90f2 Mon Sep 17 00:00:00 2001
+From: Ian McFarlane <i.mcfarlane2002@gmail.com>
+Date: Sat, 10 Sep 2022 10:19:11 -0400
+Subject: [PATCH] remove dialog box
+
+---
+ sources/code/main/modules/extensions.ts | 16 +++-------------
+ 1 file changed, 3 insertions(+), 13 deletions(-)
+
+diff --git a/sources/code/main/modules/extensions.ts b/sources/code/main/modules/extensions.ts
+index 74864ad..a56520d 100644
+--- a/sources/code/main/modules/extensions.ts
++++ b/sources/code/main/modules/extensions.ts
+@@ -49,7 +49,7 @@ async function parseImports(cssString: string):Promise<string> {
+ 
+ async function addStyle(path:string) {
+   const [
+-    { app, safeStorage, dialog },
++    { app, safeStorage },
+     { readFile, writeFile },
+     { resolve, basename }
+   ] = await Promise.all([
+@@ -65,17 +65,7 @@ async function addStyle(path:string) {
+   const data = readFile(path).then(path => optionalCrypt(path));
+   const out = resolve(app.getPath("userData"),"Themes", basename(path, ".theme.css"));
+   if(resolve(path) === out) return;
+-  const {response} = await dialog.showMessageBox({
+-    title: "WebCord plugin attestation",
+-    message: "WebCord received a request to import theme from path '"+path+"'. Proceed?",
+-    type: "question",
+-    buttons: ["&No","&Yes"],
+-    defaultId: 0,
+-    cancelId: 0,
+-    normalizeAccessKeys: true,
+-  });
+-  if(response === 1)
+-    await writeFile(out, await data);
++  await writeFile(out, await data);
+ }
+ 
+ /**
+@@ -176,4 +166,4 @@ export async function loadChromiumExtensions(session:Electron.Session) {
+ export const styles = Object.freeze({
+   load: loadStyles,
+   add: addStyle
+-});
+\ No newline at end of file
++});
+-- 
+2.36.2
+

--- a/overrides/nodejs/patches/remove-dialog-box.patch
+++ b/overrides/nodejs/patches/remove-dialog-box.patch
@@ -1,29 +1,33 @@
-From 7e9c1dec16a6650948e3612727a926deb9b7c9a4 Mon Sep 17 00:00:00 2001
+From 6097d78a8b3fff0abd5de376bf75b4548503795e Mon Sep 17 00:00:00 2001
 From: Ian McFarlane <i.mcfarlane2002@gmail.com>
 Date: Sun, 11 Sep 2022 21:41:23 -0400
 Subject: [PATCH] Remove dialog box and start webcord normally when using
  --add-css-theme
 
 ---
- sources/code/common/main.ts             |  6 ++----
+ sources/code/common/main.ts             | 10 ++++------
  sources/code/main/modules/extensions.ts | 16 +++-------------
- 2 files changed, 5 insertions(+), 17 deletions(-)
+ 2 files changed, 7 insertions(+), 19 deletions(-)
 
 diff --git a/sources/code/common/main.ts b/sources/code/common/main.ts
-index 0486f07..4a2d701 100644
+index 0486f07..1ffcf93 100644
 --- a/sources/code/common/main.ts
 +++ b/sources/code/common/main.ts
-@@ -259,9 +259,7 @@ let overwriteMain: (() => unknown) | undefined;
+@@ -258,11 +258,9 @@ let overwriteMain: (() => unknown) | undefined;
+       throw new Error("Flag 'add-css-theme' should include a value of type '{path}'.");
      if(!path.endsWith(".theme.css"))
        throw new Error("Value of flag 'add-css-theme' should point to '*.theme.css' file.");
-     overwriteMain = () => {
+-    overwriteMain = () => {
 -      styles.add(path)
 -        .then(() => process.exit(0))
 -        .catch(() => process.exit(1));
-+      styles.add(path);
-     };
+-    };
++    styles.add(path)
++      .then(() => console.log("Sucessfully added theme " + path))
++      .catch(() => process.exit(1));
    }
  }
+ {
 @@ -446,4 +444,4 @@ if(new Date().getMonth() === 3 && new Date().getDate() === 1){
    }
    // Something's wrong with your date. Websites won't load, so crash the application.


### PR DESCRIPTION
I only tested the last PR enough to make sure it was building.... I didn't make sure you could actually declaratively install themes. This fixes that. The way to install themes after this PR would be something like this (using home-manager):
```nix
{pkgs, ... }:
{
      xdg.desktopEntries.webcord = let
        theme = pkgs.fetchgit {
          url = "https://github.com/orblazer/discord-nordic";
          rev = "9808387ffcd2824e5b9a440f7e5e15ba2c8b7d00";
          sha256 = "0ahrwxkla9gqjlgff337jcna20v5ncxlkcyssli89k75axvypzr1";
        };
      in {
        name = "Webcord";
        exec = ''webcord --add-css-theme=${theme}/nordic.theme.css'';
        icon = "discord";
      };
}
 ```